### PR TITLE
Fix multiple issues on data4sdgs statistics

### DIFF
--- a/cron.js
+++ b/cron.js
@@ -5,12 +5,12 @@ const debug = require('debug')('stadistics-plugin');
 const StadisticService = require('./lib/stadistic.service');
 
 module.exports = function cron(plugin, generalConfig) {
-    debug('Loading stadistics cron');
+    debug('Loading statistics cron');
     const connection = mongoose.createConnection(`${generalConfig.mongoUri}`);
     const stadisticService = new StadisticService(connection);
     async function tick() {
         try {
-            debug('Executing tick in stadistics microservice');
+            debug('Executing tick in statistics microservice');
             await stadisticService.completeGeoInfo();
         } catch (error) {
             debug('Error: ', error);

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function init() {
 function middleware(app, plugin, generalConfig) {
     const connection = mongoose.createConnection(`${generalConfig.mongoUri}`);
     debug('Loading stadistics-plugin');
-    app.use(stadisticService(connection, plugin).middleware);
+    app.use(stadisticService(connection).middleware);
     app.use(stadisticRouter(connection).middleware());
 }
 

--- a/lib/stadistic.router.js
+++ b/lib/stadistic.router.js
@@ -10,10 +10,11 @@ const ApiRouter = new Router({
 
 function getMiddleware(connection) {
     const StadisticModel = stadisticFunction(connection);
+
     class StadisticRouter {
 
         static async get(ctx) {
-            debug('Obtaining stadistics');
+            debug('Obtaining statistics');
 
             let format = 'json';
             if (ctx.query && ctx.query.format) {
@@ -23,81 +24,92 @@ function getMiddleware(connection) {
             const filter = {};
             Object.keys(ctx.query).forEach(key => {
                 switch (key) {
-                    case 'authenticated':
-                        filter.anonymous = ctx.query[key] !== 'true';
-                        break;
-                    case 'period':
-                        const periods = ctx.query.period.split(',');
-                        filter.date = {
-                            $gte: new Date(periods[0]),
-                            $lt: periods.length > 1 ? new Date(periods[1]) : new Date(),
-                        }
-                        console.log(filter.date);
-                        break;
-                    case 'userEmail':
-                        filter['loggedUser.email'] = {
-                            $eq: ctx.query.userEmail,
-                        };
-                        break;
-                    case 'sandbox':
-                        filter.sandbox = ctx.query[key] === 'true';
-                    case 'code':
-                        filter.code = parseInt(ctx.query[key], 10);
-                        break;
-                    case 'datasetProvider':
-                    case 'datasetId':
-                    case 'datasetName':
-                    case 'requestType':
-                    case 'client':
 
-                        filter[key] = ctx.query[key];
-                        break;
-                    default:
-                        break;
+                case 'authenticated': {
+                    filter.anonymous = ctx.query[key] === 'false';
+                    break;
+                }
+                case 'period': {
+                    const periods = ctx.query.period.split(',');
+                    filter.date = {
+                        $gte: new Date(periods[0]),
+                        $lt: periods.length > 1 ? new Date(periods[1]) : new Date(),
+                    };
+                    console.log(filter.date);
+                    break;
+                }
+                case 'userEmail': {
+                    filter['loggedUser.email'] = {
+                        $eq: ctx.query.userEmail,
+                    };
+                    break;
+                }
+                case 'sandbox': {
+                    filter.sandbox = ctx.query[key] === 'true';
+                    break;
+                }
+                case 'code': {
+                    filter.code = parseInt(ctx.query[key], 10);
+                    break;
+                }
+                case 'datasetProvider':
+                case 'datasetId':
+                case 'datasetName':
+                case 'requestType':
+                case 'client': {
+                    filter[key] = ctx.query[key];
+                    break;
+                }
+                default:
+                    break;
+
                 }
             });
             if (ctx.query.sort) {
                 switch (ctx.query.sort) {
-                    case 'authenticated':
-                        ctx.query.sort = 'anonymous';
-                        break;
-                    
-                    case 'userEmail':
-                        ctx.query.sort = 'loggedUser.email';
-                        break;
-                    case 'sandbox':
-                    case 'code':
-                    case 'datasetProvider':
-                    case 'datasetId':
-                    case 'datasetName':
-                    case 'client':
-                    default:
-                        break;
+
+                case 'authenticated':
+                    ctx.query.sort = 'anonymous';
+                    break;
+
+                case 'userEmail':
+                    ctx.query.sort = 'loggedUser.email';
+                    break;
+                case 'sandbox':
+                case 'code':
+                case 'datasetProvider':
+                case 'datasetId':
+                case 'datasetName':
+                case 'client':
+                default:
+                    break;
+
                 }
             }
             if (ctx.query.group) {
                 switch (ctx.query.group) {
-                    case 'authenticated':
-                        ctx.query.group = 'anonymous';
-                        break;
-                    
-                    case 'userEmail':
-                        ctx.query.group = 'loggedUser.email';
-                        break;
-                    case 'userId':
-                        ctx.query.group = 'loggedUser.id';
-                        break;
-                    case 'sandbox':
-                    case 'code':
-                    case 'datasetProvider':
-                    case 'datasetId':
-                    case 'datasetName':
-                    case 'client':
-                    default:
-                        break;
+
+                case 'authenticated':
+                    ctx.query.group = 'anonymous';
+                    break;
+
+                case 'userEmail':
+                    ctx.query.group = 'loggedUser.email';
+                    break;
+                case 'userId':
+                    ctx.query.group = 'loggedUser.id';
+                    break;
+                case 'sandbox':
+                case 'code':
+                case 'datasetProvider':
+                case 'datasetId':
+                case 'datasetName':
+                case 'client':
+                default:
+                    break;
+
                 }
             }
-          
 
             if (ctx.query.group) {
                 console.log([
@@ -189,7 +201,7 @@ function getMiddleware(connection) {
                         $avg: '$time',
                     },
                     count: {
-                        $sum: 1
+                        $sum: 1,
                     },
                 },
             });
@@ -264,7 +276,7 @@ function getMiddleware(connection) {
         }
 
         static async requestByDay(ctx) {
-            debug('Obtaining stadistics aggrouped');
+            debug('Obtaining grouped statistics');
             let filter = null;
             if (ctx.query.from || ctx.query.to) {
                 filter = {
@@ -316,4 +328,5 @@ function getMiddleware(connection) {
 
     return ApiRouter;
 }
+
 module.exports = getMiddleware;

--- a/lib/stadistic.service.js
+++ b/lib/stadistic.service.js
@@ -3,30 +3,30 @@ const stadisticFunction = require('./stadistic.model');
 const geoip = require('geoip-lite');
 const rp = require('request-promise');
 
-function getService(connection, plugin) {
+function getService(connection) {
 
     const StadisticModel = stadisticFunction(connection);
 
     class StadisticService {
 
         static async completeGeoInfo() {
-            debug('Loading stadistics to complete geo info');
-            const stadistics = await StadisticModel.find({
+            debug('Loading statistics to complete geo info');
+            const statistics = await StadisticModel.find({
                 ip: {
                     $exists: true,
                 },
                 'geo.completed': false,
             }).limit(10000).exec();
-            debug('Ips found ', stadistics.length);
-            for (let i = 0, length = stadistics.length; i < length; i++) {
-                if (stadistics[i].ip && stadistics[i].ip.indexOf('127.0.0.1') === -1) {
-                    let ip = stadistics[i].ip;
+            debug('Ips found ', statistics.length);
+            for (let i = 0, length = statistics.length; i < length; i++) {
+                if (statistics[i].ip && statistics[i].ip.indexOf('127.0.0.1') === -1) {
+                    let ip = statistics[i].ip;
                     if (ip.indexOf(',') >= 0) {
                         ip = ip.split(',')[1];
                     }
                     const geo = geoip.lookup(ip);
                     if (geo) {
-                        stadistics[i].geo = {
+                        statistics[i].geo = {
                             city: geo.city,
                             country: geo.country,
                             region: geo.region,
@@ -34,16 +34,16 @@ function getService(connection, plugin) {
                             completed: true,
                         };
                     } else {
-                        stadistics[i].geo = {
+                        statistics[i].geo = {
                             completed: true,
                         };
                     }
                 } else {
-                    stadistics[i].geo = {
+                    statistics[i].geo = {
                         completed: true,
                     };
                 }
-                await stadistics[i].save();
+                await statistics[i].save();
             }
             debug('Finish complete geo');
         }
@@ -53,16 +53,16 @@ function getService(connection, plugin) {
                 let dataset = null;
                 let id = null;
                 let requestType = 'other';
-                if (/dataset/g.test(ctx.path)) {
+                if (/v1\/dataset/g.test(ctx.path)) {
                     debug('Dataset endpoint');
                     requestType = 'dataset';
                     const groups = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/g.exec(ctx.path);
                     if (groups && groups.length > 1) {
                         id = groups[1];
-                        
+
                         if (id) {
                             dataset = await rp({
-                                url: `${plugin.config.url}/v1/dataset/${id}?internal=true`,
+                                url: `${ctx.request.protocol}://${ctx.request.get('host')}/v1/dataset/${id}?internal=true`,
                                 method: 'GET',
                                 json: true,
                             });
@@ -70,18 +70,18 @@ function getService(connection, plugin) {
                             dataset = dataset.data;
                         }
                     }
-                } else if (/query/g.test(ctx.path) && ctx.query.sql) {
+                } else if (/v1\/query/g.test(ctx.path) && ctx.query.sql) {
                     debug('query');
                     requestType = 'query';
                     const convert = await rp({
-                        url: `${plugin.config.url}/v1/convert/sql2SQL?sql=${ctx.query.sql}&internal=true`,
+                        url: `${ctx.request.protocol}://${ctx.request.get('host')}/v1/convert/sql2SQL?sql=${ctx.query.sql}&internal=true`,
                         method: 'GET',
                         json: true,
                     });
                     id = convert.data.attributes.jsonSql.from;
                     if (id) {
                         dataset = await rp({
-                            url: `${plugin.config.url}/v1/dataset/${id}?internal=true`,
+                            url: `${ctx.request.protocol}://${ctx.request.get('host')}/v1/dataset/${id}?internal=true`,
                             method: 'GET',
                             json: true,
                         });
@@ -94,7 +94,7 @@ function getService(connection, plugin) {
                 debug(dataset);
                 if (dataset) {
                     debug('Setting dataset info');
-                    model.datasetId = id;
+                    model.datasetId = dataset.id;
                     model.datasetName = dataset.attributes.name;
                     model.datasetProvider = dataset.attributes.provider;
                     model.sandbox = dataset.attributes.sandbox;
@@ -117,13 +117,13 @@ function getService(connection, plugin) {
                 code = e.status || 500;
                 throw e;
             } finally {
-                if ((!ctx.state || !ctx.state.microservice ) && !ctx.query.internal && !ctx.path.startsWith('/api') && (!ctx.state || !ctx.state.user || ctx.state.user.id !== 'microservice')) {
+                if ((!ctx.state || !ctx.state.microservice) && !ctx.query.internal && !ctx.path.startsWith('/api') && (!ctx.state || !ctx.state.user || ctx.state.user.id !== 'microservice')) {
                     if (ctx.state.source && ctx.state.source.path) {
                         let model = {
                             sourcePath: ctx.state.source.path,
                             sourceMethod: ctx.state.source.method,
                             error,
-                            code: code || ctx.response.statusCode,
+                            code: code || ctx.response.statusCode || 200,
                             cached: false,
                             time: Date.now() - first,
                             body: ctx.request.body,
@@ -140,7 +140,7 @@ function getService(connection, plugin) {
                             model.client = 'front';
                         }
                         model = await StadisticService.obtainDataDataset(ctx, model);
-                        debug('Saving stadistic');
+                        debug('Saving statistic');
                         debug(JSON.stringify(ctx.state.redirect));
                         await new StadisticModel(model).save();
                     } else {
@@ -148,7 +148,7 @@ function getService(connection, plugin) {
                             sourcePath: ctx.path,
                             sourceMethod: ctx.request.method,
                             error,
-                            code: code || ctx.response.statusCode,
+                            code: code || ctx.response.statusCode || 200,
                             body: ctx.request.body,
                             cached: ctx.state.isCached || false,
                             time: Date.now() - first,
@@ -166,7 +166,7 @@ function getService(connection, plugin) {
                         }
 
 
-                        debug('Saving stadistic');
+                        debug('Saving statistic');
                         await new StadisticModel(model).save();
 
                     }
@@ -175,6 +175,8 @@ function getService(connection, plugin) {
         }
 
     }
+
     return StadisticService;
 }
+
 module.exports = getService;


### PR DESCRIPTION
- Fixed a bunch of typos, because I'm pretty sure I have OCD
- Removed `plugin` and `config` usage in favor of getting CT's url from the request (CT doesn't have it's own url in the config or env vars anyways)
- Added a missing "break" that was preventing filter by sandbox from working
- Added `code` fallback to 200 as successful requests had `null` code
- On `query` type query using `select x from slug` the stored dataset id would actually be the slug. fixed that
- Minor change in filter by `authenticated` logic to fallback to true if param is present and no value is defined 
- Fixed CS because eslint made the code look like a christmas tree